### PR TITLE
Adds ASJOverflowMenuDelegate.

### DIFF
--- a/ASJOverflowButton/ASJOverflowButton.h
+++ b/ASJOverflowButton/ASJOverflowButton.h
@@ -35,6 +35,11 @@ typedef void (^HideMenuBlock)();
 @interface ASJOverflowButton : UIBarButtonItem
 
 /**
+ *  Called in response to menu item selection. Optional.
+ */
+@property (nullable, weak, nonatomic) id <ASJOverflowMenuDelegate> delegate;
+
+/**
  *  The overflow menu's background color. Defaults to white.
  */
 @property (nullable, strong, nonatomic) UIColor *menuBackgroundColor;

--- a/ASJOverflowButton/ASJOverflowButton.m
+++ b/ASJOverflowButton/ASJOverflowButton.m
@@ -221,6 +221,7 @@
        weakSelf.hideMenuBlock();
      }
    }];
+  [_overflowMenu setDelegate:_delegate];
 }
 
 - (void)destroyWindowAndMenu

--- a/ASJOverflowButton/ASJOverflowMenu.h
+++ b/ASJOverflowButton/ASJOverflowMenu.h
@@ -60,7 +60,18 @@ static inline SeparatorInsets SeparatorInsetsMake(CGFloat left, CGFloat right)
   return insets;
 }
 
+@class ASJOverflowMenu;
+
+@protocol ASJOverflowMenuDelegate <NSObject>
+- (void)overflowMenu:(ASJOverflowMenu *)sender didSelectItem:(ASJOverflowItem *)item atIndex:(NSUInteger)idx;
+@end
+
 @interface ASJOverflowMenu : UIView
+
+/**
+ *  Called in response to menu item selection. Optional.
+ */
+@property (nullable, weak, nonatomic) id <ASJOverflowMenuDelegate> delegate;
 
 /**
  *  An array of ASJOverflowItems to show on the menu.

--- a/ASJOverflowButton/ASJOverflowMenu.m
+++ b/ASJOverflowButton/ASJOverflowMenu.m
@@ -265,6 +265,9 @@ static NSString *const kCellIdentifier = @"cell";
   if (_itemTapBlock) {
     _itemTapBlock(_items[indexPath.row], indexPath.row);
   }
+  if (_delegate) {
+    [_delegate overflowMenu:self didSelectItem:_items[indexPath.row] atIndex:indexPath.row];
+  }
   [self hideMenu];
   [tableView deselectRowAtIndexPath:indexPath animated:YES];
 }


### PR DESCRIPTION
Instead of setting a block on ASJOverflowButton that gets passed along to and called by ASJOverflowMenu on item selection, this allows for setting a delegate with response method `-[overflowMenu:didSelectItem:atIndex:]`.