### PR TITLE
Adds ItemTapBlock to ASJOverflowItem.

### DIFF
--- a/ASJOverflowButton/ASJOverflowButton.h
+++ b/ASJOverflowButton/ASJOverflowButton.h
@@ -153,6 +153,11 @@ typedef void (^HideMenuBlock)();
 @property (nullable, strong, nonatomic) UIColor *backgroundColor;
 
 /**
+ *  A block that is called when the overflow menu item is tapped.
+ */
+@property (nullable, strong, nonatomic) ItemTapBlock itemTapBlock;
+
+/**
  *  A convenience constructor to create ASJOverflowItems.
  *
  *  @param name  The overflow item's name.
@@ -160,6 +165,16 @@ typedef void (^HideMenuBlock)();
  *  @return An instance of ASJOverflowItem.
  */
 + (ASJOverflowItem *)itemWithName:(NSString *)name;
+
+/**
+ *  A convenience constructor to create ASJOverflowItems.
+ *
+ *  @param name  The overflow item's name.
+ *  @param itemtapBlock  A block that gets called when the overflow item is tapped. Optional.
+ *
+ *  @return An instance of ASJOverflowItem.
+ */
++ (ASJOverflowItem *)itemWithName:(NSString *)name tapBlock:(ItemTapBlock)itemTapBlock;
 
 /**
  *  A convenience constructor to create ASJOverflowItems.

--- a/ASJOverflowButton/ASJOverflowButton.m
+++ b/ASJOverflowButton/ASJOverflowButton.m
@@ -247,6 +247,14 @@
   return item;
 }
 
++ (ASJOverflowItem *)itemWithName:(NSString *)name tapBlock:(ItemTapBlock)itemTapBlock
+{
+  ASJOverflowItem *item = [[ASJOverflowItem alloc] init];
+  item.name = name;
+  item.itemTapBlock = itemTapBlock;
+  return item;
+}
+
 + (ASJOverflowItem *)itemWithName:(NSString *)name image:(UIImage *)image backgroundColor:(nullable UIColor *)backgroundColor
 {
   ASJOverflowItem *item = [[ASJOverflowItem alloc] init];

--- a/ASJOverflowButton/ASJOverflowMenu.m
+++ b/ASJOverflowButton/ASJOverflowMenu.m
@@ -265,6 +265,10 @@ static NSString *const kCellIdentifier = @"cell";
   if (_itemTapBlock) {
     _itemTapBlock(_items[indexPath.row], indexPath.row);
   }
+  ASJOverflowItem *item = _items[indexPath.row];
+  if (item.itemTapBlock) {
+    item.itemTapBlock(item, indexPath.row);
+  }
   [self hideMenu];
   [tableView deselectRowAtIndexPath:indexPath animated:YES];
 }


### PR DESCRIPTION
This allows you to attach an ItemTapBlock to individual ASJOverflowItems rather than to the ASJOverflowButton / ASJOverflowMenu, allowing for cleaner code where you don't have to check which ASJOverflowItem is triggering your ItemTapBlock.